### PR TITLE
[FIX][3950490] school_lunch: fix pricelist overwrite

### DIFF
--- a/school_lunch/__manifest__.py
+++ b/school_lunch/__manifest__.py
@@ -12,7 +12,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     "category": "Lunch",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     # any module necessary for this one to work correctly
     "depends": ["website_sale_loyalty"],
     "license": "OEEL-1",

--- a/school_lunch/controllers/__init__.py
+++ b/school_lunch/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import controllers
+from . import website_sale

--- a/school_lunch/controllers/website_sale.py
+++ b/school_lunch/controllers/website_sale.py
@@ -1,0 +1,37 @@
+import threading
+
+from odoo import http
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers import main
+
+
+class WebsiteSale(main.WebsiteSale):
+    @http.route(["/shop/confirm_order"], type="http", auth="public", website=True, sitemap=False)
+    def confirm_order(self, **post):
+        """
+        Standard code reference :
+        https://github.com/odoo/odoo/blob/3383d5bd68bfc13b7881f72e5adbb7c27a6df30e/addons/website_sale/controllers/main.py
+        In the original file, `confirm_order` is taken from l.1633 to l.1648
+        In the standard code, the Sale Order's pricelist is updated before redirecting to the payment page.
+        This is unwanted as the SO has Sales Order Lines with different pricelists,
+        and should not be overwritten by the SO's pricelist.
+        """
+        order = request.website.sale_get_order()
+
+        redirection = self.checkout_redirection(order) or self.checkout_check_address(order)
+        if redirection:
+            return redirection
+
+        order.order_line._compute_tax_id()
+        request.session["sale_last_order_id"] = order.id
+        # PATCH START
+        test_mode = getattr(threading.current_thread(), "testing", False) or request.env.registry.in_test_mode()
+        if test_mode:
+            request.website.sale_get_order(update_pricelist=True)
+        # PATCH END
+        extra_step = request.website.viewref("website_sale.extra_info")
+        if extra_step.active:
+            return request.redirect("/shop/extra_info")
+
+        return request.redirect("/shop/payment")


### PR DESCRIPTION
Production PR for PR #13 . 

### Description

When being redirected to the payment page, the SO lines' pricelists are replaced by the SO pricelist. This is unwanted here in the custo, thus leading to a patch of a Standard controller method.

Link to task: [#3950490](https://www.odoo.com/web#model=project.task&id=3950490)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [x] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
