### PR TITLE
[FIX][3950490] school_lunch: give access rights to portal users

### DIFF
--- a/school_lunch/__manifest__.py
+++ b/school_lunch/__manifest__.py
@@ -12,7 +12,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     "category": "Lunch",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
     # any module necessary for this one to work correctly
     "depends": ["website_sale_loyalty"],
     "license": "OEEL-1",

--- a/school_lunch/security/ir.model.access.csv
+++ b/school_lunch/security/ir.model.access.csv
@@ -4,6 +4,10 @@ access_school_lunch_menu,school_lunch.menu,model_school_lunch_menu,base.group_us
 access_school_lunch_class_name,school_lunch.class_name,model_school_lunch_class_name,base.group_user,1,1,1,1
 access_school_lunch_order,school_lunch.order,model_school_lunch_order,base.group_user,1,1,1,1
 access_school_lunch_kid,school_lunch.kid,model_school_lunch_kid,base.group_user,1,1,1,1
+access_school_lunch_allergy_portal,school_lunch.allergy,model_school_lunch_allergy,base.group_portal,1,0,0,0
+access_school_lunch_menu_portal,school_lunch.menu,model_school_lunch_menu,base.group_portal,1,0,0,0
+access_school_lunch_class_name_portal,school_lunch.class_name,model_school_lunch_class_name,base.group_portal,1,0,0,0
+access_school_lunch_kid_portal,school_lunch.kid,model_school_lunch_kid,base.group_portal,1,0,0,0
 access_school_lunch_allergy_anon,school_lunch.allergy,model_school_lunch_allergy,base.group_public,1,0,0,0
 access_school_lunch_menu_anon,school_lunch.menu,model_school_lunch_menu,base.group_public,1,0,0,0
 access_school_lunch_class_name_anon,school_lunch.class_name,model_school_lunch_class_name,base.group_public,1,0,0,0


### PR DESCRIPTION
Production PR for PR #15.

### Description

It appears that the `base.group_public` access rights are not transitive to the `base.group_portal` group. The rights are specified for all portal Users in the `ir.model.access` table, as many Portal Users have been unable to access some of the Website custom views.

Link to task: [#3950490](https://www.odoo.com/web#model=project.task&id=3950490)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [x] The commits pass test and the branch is green
> There is a `payment_provider` error which is unrelated to the custom code & modifications done here
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
