### PR TITLE
[FIX][3957504] school_lunch: fix gantt total

### DIFF
--- a/school_lunch/__manifest__.py
+++ b/school_lunch/__manifest__.py
@@ -12,7 +12,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     "category": "Lunch",
-    "version": "17.0.1.0.2",
+    "version": "17.0.1.0.3",
     # any module necessary for this one to work correctly
     "depends": ["website_sale_loyalty"],
     "license": "OEEL-1",

--- a/school_lunch/models/school_lunch.py
+++ b/school_lunch/models/school_lunch.py
@@ -110,11 +110,16 @@ class Order(models.Model):
     class_id = fields.Many2one("school_lunch.class_name", string="Class", related="kid_id.class_id", store=True)
     menu_id = fields.Many2one("school_lunch.menu", "Menu", required=True)
     date = fields.Date("Day", related="menu_id.date", index=True, store=True)
+    date_end_gantt = fields.Datetime("Day End Gantt", compute="_compute_date_end_gantt", search=False, store=True)
     meal_type = fields.Selection(related="menu_id.meal_type", string="Meal Type", store=True)
     color = fields.Integer("Color", compute="_compute_color")
     sale_line_id = fields.Many2one("sale.order.line", "Sale Order Line", ondelete="cascade")
     state = fields.Selection([("draft", "Draft"), ("confirmed", "Confirmed")], "State", default="draft")
     class_type = fields.Selection(related="class_id.class_type", string="Class Type", store=True)
+
+    def _compute_date_end_gantt(self):
+        for order in self:
+            order.date_end_gantt = order.date + relativedelta(hours=1)
 
     @api.depends("meal_type")
     def _compute_color(self):

--- a/school_lunch/views/views.xml
+++ b/school_lunch/views/views.xml
@@ -257,7 +257,7 @@
         <gantt
                     string="Kids Lunch"
                     date_start="date"
-                    date_stop="date"
+                    date_stop="date_end_gantt"
                     color="color"
                     default_group_by="kid_id"
                     default_scale="month"


### PR DESCRIPTION
Production PR for PR #17.

This PR is a copy of that on the Odoo-ps Repository [PR#15](https://github.com/odoo-ps/psbe-school/pull/15). The comments and reviews are on the other PR.


### Description

The gantt total was empty: the `date_stop` var being the same as `date_start`, the Gantt view was not counting the tasks as real tasks. A new date field is created.

![image (1)](https://github.com/odoo-ps/psbe-school/assets/100482501/7bbbf9c9-dc10-42e8-8d59-0136b450b380)

Link to task: [#3957504](https://www.odoo.com/web#model=project.task&id=3957504)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [x] The commits pass test and the branch is green
> There is one unrelated red error on SH.
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
