### PR TITLE
[FIX][4014282] school_lunch: add dependency to gantt date

### DIFF
--- a/school_lunch/__manifest__.py
+++ b/school_lunch/__manifest__.py
@@ -12,7 +12,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     "category": "Lunch",
-    "version": "17.0.1.0.4",
+    "version": "17.0.1.0.5",
     # any module necessary for this one to work correctly
     "depends": ["website_sale_loyalty"],
     "license": "OEEL-1",

--- a/school_lunch/migrations/17.0.1.0.5/end-10-migrate.py
+++ b/school_lunch/migrations/17.0.1.0.5/end-10-migrate.py
@@ -1,0 +1,7 @@
+from odoo.upgrade import util
+
+
+def migrate(cr, _):
+    env = util.env(cr)
+    records_to_compute = env["school_lunch.order"].search([("date_end_gantt", "=", False)])
+    util.recompute_fields(cr, "school_lunch.order", ["date_end_gantt"], ids=records_to_compute.ids)

--- a/school_lunch/models/school_lunch.py
+++ b/school_lunch/models/school_lunch.py
@@ -118,6 +118,7 @@ class Order(models.Model):
     state = fields.Selection([("draft", "Draft"), ("confirmed", "Confirmed")], "State", default="draft")
     class_type = fields.Selection(related="class_id.class_type", string="Class Type", store=True)
 
+    @api.depends("date")
     def _compute_date_end_gantt(self):
         for order in self:
             order.date_end_gantt = order.date + relativedelta(hours=1)


### PR DESCRIPTION
This PR is a production PR for #23 


### Description

- The previous forgot to add a `@depends` on the new `date_end_gantt` field. As such, it was never computed when creating a record.
A migration script is created to compute this field for records that were created between the first fix and now.

Tested locally on a production copy.

Link to task: [#4014282](https://www.odoo.com/web#model=project.task&id=4014282)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
