### PR TITLE
[UPG][4014526] school_lunch: fix coupon pricelist overwrite

### DIFF
--- a/school_lunch/__manifest__.py
+++ b/school_lunch/__manifest__.py
@@ -12,7 +12,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     "category": "Lunch",
-    "version": "17.0.1.0.5",
+    "version": "17.0.1.0.6",
     # any module necessary for this one to work correctly
     "depends": ["website_sale_loyalty"],
     "license": "OEEL-1",

--- a/school_lunch/controllers/website_sale.py
+++ b/school_lunch/controllers/website_sale.py
@@ -35,3 +35,34 @@ class WebsiteSale(main.WebsiteSale):
             return request.redirect("/shop/extra_info")
 
         return request.redirect("/shop/payment")
+
+    @http.route(["/shop/pricelist"], type="http", auth="public", website=True, sitemap=False)
+    def pricelist(self, promo, **post):
+        """
+        Standard code reference :
+        https://github.com/odoo/odoo/blob/3383d5bd68bfc13b7881f72e5adbb7c27a6df30e/addons/website_sale/controllers/main.py
+        In the original file, `pricelist` is taken from l.750 to l.769
+        In the standard code, the Sale Order's pricelist is updated when an empty promo code is used.
+        This is unwanted as the SO has Sales Order Lines with different pricelists,
+        and should not be overwritten by the SO's pricelist.
+        """
+        redirect = post.get("r", "/shop/cart")
+        # empty promo code is used to reset/remove pricelist (see `sale_get_order()`)
+        if promo:
+            pricelist_sudo = request.env["product.pricelist"].sudo().search([("code", "=", promo)], limit=1)
+            if not (pricelist_sudo and request.website.is_pricelist_available(pricelist_sudo.id)):
+                return request.redirect("%s?code_not_available=1" % redirect)
+
+            request.session["website_sale_current_pl"] = pricelist_sudo.id
+            # TODO find the best way to create the order with the correct pricelist directly ?
+            # not really necessary, but could avoid one write on SO record
+            order_sudo = request.website.sale_get_order(force_create=True)
+            order_sudo._cart_update_pricelist(pricelist_id=pricelist_sudo.id)
+        else:
+            order_sudo = request.website.sale_get_order()
+            # PATCH START
+            test_mode = getattr(threading.current_thread(), "testing", False) or request.env.registry.in_test_mode()
+            if order_sudo and test_mode:
+                order_sudo._cart_update_pricelist(update_pricelist=True)
+            # PATCH END
+        return request.redirect(redirect)


### PR DESCRIPTION
This PR is a copy of [#20](https://github.com/odoo-ps/psbe-school/pull/20).

### Description

When adding an empty coupon code, the Standard code updates resets all pricelists, which is unwanted.
Patching the Standard code is enough to prevent this behavior.

Link to task: [#4014526](https://www.odoo.com/web#model=project.task&id=4014526)

### All Submissions:

* [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
